### PR TITLE
render_json -> render( json => ... )

### DIFF
--- a/lib/Mojolicious/Plugin/JSUrlFor.pm
+++ b/lib/Mojolicious/Plugin/JSUrlFor.pm
@@ -39,7 +39,7 @@ sub register {
                 $names2paths{$route->name} = $path;
             }
             
-            my $json_routes = $c->render_json( \%names2paths, partial=>1 );
+            my $json_routes = $c->render( json => \%names2paths, partial=>1 );
             utf8::decode( $json_routes );
 
             my $js = <<"JS";


### PR DESCRIPTION
render_json was removed in Mojolicious 4.0
