### PR TITLE
render is changed to render_to_string. Render returns 1 instead of the r...

### DIFF
--- a/lib/Mojolicious/Plugin/JSUrlFor.pm
+++ b/lib/Mojolicious/Plugin/JSUrlFor.pm
@@ -51,7 +51,10 @@ sub register {
                 $names2paths{$route->name} = $path;
             }
 
-            my $json_routes = $c->render( json => \%names2paths, partial=>1 );
+            my $json_routes = $c->can("render_to_string") ? 
+              $c->render_to_string( json => \%names2paths ) : 
+              $c->render( json => \%names2paths, partial=>1 );
+
             utf8::decode( $json_routes );
 
             my $js = <<"JS";


### PR DESCRIPTION
Render works differently since the Mojolicious 5.0: it returns a boolean about success of the render process. They introduced a new method: `render_to_string`. I kept `render(..., partial => 1)` for older versions.
